### PR TITLE
Use node_redis v0.8.3 or remove explicit version dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "redis"
   ],
   "dependencies" : {
-    "redis" : "0.8.2",
+    "redis" : "0.8.3",
     "q" : "0.9.2"
   },
   "devDependencies" : {


### PR DESCRIPTION
Any chance we could bump up the node_redis dependency to the latest version or remove the explicit version dependency altogether?

Thanks for building this lib! 
I've been evaluating this library and it seems to work as expected (basic use case of failover to a slave when master dies).
I really like this lightweight approach as compared to the **heavier** solutions mentioned in mranney/node_redis#302

I'm wondering if you have used this lib in a production environment? Any issues to be aware of?
