### PR TITLE
Updated package.json to fix ETIMEDOUT after a period of inactivity.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redis-sentinel",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Redis sentinel client for nodejs",
   "main": "index.js",
   "scripts": {
@@ -14,7 +14,7 @@
     "redis"
   ],
   "dependencies" : {
-    "redis" : "0.10.3",
+    "redis" : "0.11.x",
     "q" : "0.9.2"
   },
   "devDependencies" : {


### PR DESCRIPTION
Updated package.json to update depenencies version of redis to 0.11.x in order to have socket_keepalive to set keep-alive on socket preveting ETIMEDOUT after a period of inactivity. Also, bumped version.

Related issues on node_redis: 
- https://github.com/mranney/node_redis/pull/570
- https://github.com/mranney/node_redis/issues/530

On a sidenote this version brings also: (https://github.com/mranney/node_redis/blob/master/changelog.md)
- IPv6 Support. (Yann Stephan)
- Revert error emitting and go back to throwing errors. (Bryce Baril)
- Set socket_keepalive to prevent long-lived client timeouts. (mohit)
- Correctly reset retry timer. (ouotuo)
- Domains protection from bad user exit. (Jake Verbaten)
- Fix reconnection socket logic to prevent misqueued entries. (Iain Proctor)
