### PR TITLE
fix: Reconnect process crash

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,6 +67,12 @@ Sentinel.prototype.createClient = function(masterName, opts) {
                 resolver(self.endpoints, masterName, function(_err, ip, port) {
                     if (_err) { oldEmit.call(client, 'error', _err); }
                     // Try and reconnect
+
+                    client.connectionOption = {
+                        port: port,
+                        host: ip
+                    };
+
                     client.port = port;
                     client.host = ip;
                 });


### PR DESCRIPTION
node_redis reconnects using self.connectionOption object (https://github.com/mranney/node_redis/blob/master/index.js#L535), this property does not get set when net.Socket is passed in to the RedisClient constructor.

As a workaround set the property whenever `refreshEndpoints` is successful in resolving new master.

Is this due to node_redis version updates? Were there changes in the way redis stores the host and port for reconnect purposes?
