### PR TITLE
Pub/Sub subscribe to +switch-master events.

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,11 +97,17 @@ Sentinel.prototype.createClientInternal = function(masterName, opts) {
             client.on('reconnecting', refreshEndpoints);
 
             function refreshEndpoints() {
+                client.connectionOption.port = "";
+                client.connectionOption.host = "";
                 resolver(self.endpoints, masterName, function(_err, ip, port) {
-                    if (_err) { oldEmit.call(client, 'error', _err); }
-                    // Try and reconnect
-                    client.connectionOption.port = port;
-                    client.connectionOption.host = ip;
+                    if (_err) {
+                        oldEmit.call(client, 'error', _err);
+                    } else {
+                        // Try reconnecting.
+                        client.connectionOption.port = port;
+                        client.connectionOption.host = ip;
+                        client.connection_gone("sentinel induced refresh");
+                    }
                 });
             }
 


### PR DESCRIPTION
The master can change even without a disconnect happening to the client. In order to get this change the clients must subscribe to the +switch-master message. This needs to be subscribed before the client connection is established to avoid race conditions.
