### PR TITLE
Remove event listeners of old redis client's stream

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,6 +99,7 @@ Sentinel.prototype.createClientInternal = function(masterName, opts) {
             function refreshEndpoints() {
                 client.connectionOption.port = "";
                 client.connectionOption.host = "";
+                client.stream.removeAllListeners();
                 resolver(self.endpoints, masterName, function(_err, ip, port) {
                     if (_err) {
                         oldEmit.call(client, 'error', _err);


### PR DESCRIPTION
This fix related to the issue #31. Thanks for the efforts.