### PR TITLE
Actively manage internal clients list in order not to retain dead connections

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,8 +67,8 @@ Sentinel.prototype.createClientInternal = function(masterName, opts) {
     var self = this;
 
     client.on('end', function() {
-        // if we're purposefully ending and we're not our pubsub client, forget us
-        if (this.closing && self.pubsub.indexOf(this) === -1) {
+        // if we're purposefully ending, forget us
+        if (this.closing) {
             var index = self.clients.indexOf(this);
             if (index !== -1) {
                 self.clients.splice(index, 1);

--- a/index.js
+++ b/index.js
@@ -66,6 +66,16 @@ Sentinel.prototype.createClientInternal = function(masterName, opts) {
 
     var self = this;
 
+    client.on('end', function() {
+        // if we're purposefully ending and we're not our pubsub client, forget us
+        if (this.closing && self.pubsub.indexOf(this) === -1) {
+            var index = self.clients.indexOf(this);
+            if (index !== -1) {
+                self.clients.splice(index, 1);
+            }
+        }
+    });
+
     function connectClient(resolver) {
         return function(err, host, port) {
             if (err) {
@@ -153,6 +163,10 @@ Sentinel.prototype.createClientInternal = function(masterName, opts) {
  * Ensure that all clients are trying to reconnect.
  */
 Sentinel.prototype.reconnectAllClients = function() {
+    // clients in 'closing' state were purposefully closed, and won't ever
+    // reconnect; remove those from our clients before proceeding
+    this.clients = this.clients.filter(function(client) { return !client.closing; });
+
     this.clients.forEach(function(client) {
         // It is safe to call this multiple times in quick succession, as
         // might happen with multiple Sentinel instances. Each client

--- a/test/test.js
+++ b/test/test.js
@@ -166,4 +166,61 @@ describe('Redis Sentinel tests', function() {
             });
         });
     });
+
+    describe('client management', function () {
+        it('should clear client entries when they quit', function (done) {
+            var endpoints = [{host: '127.0.0.1', port: 26380}];
+            var instance = sentinel.Sentinel(endpoints);
+            var redisClient1 = instance.createClient('mymaster');
+            redisClient1.on('ready', function () {
+                // one pubsub, one actual
+                expect(instance.clients.length).to.equal(2);
+
+                var redisClient2 = instance.createClient('mymaster');
+                redisClient2.on('ready', function () {
+                    expect(instance.clients.length).to.equal(3);
+                    redisClient2.quit();
+                });
+
+                redisClient2.on('end', function () {
+                    expect(instance.clients.length).to.equal(2);
+                    expect(redisClient2.info()).to.not.be.ok;
+
+                    redisClient1.info(function(err, info) {
+                        expect(err).to.be.null;
+                        expect(info).to.be.ok;
+
+                        done();
+                    });
+                });
+            });
+        });
+
+        it('should eventually clear client entries when reconnecting', function (done) {
+            var endpoints = [{host: '127.0.0.1', port: 26380}];
+            var instance = sentinel.Sentinel(endpoints);
+            var redisClient1 = instance.createClient('mymaster');
+            redisClient1.on('ready', function () {
+                // one pubsub, one actual
+                expect(instance.clients.length).to.equal(2);
+
+                var redisClient2 = instance.createClient('mymaster');
+                redisClient2.on('ready', function () {
+                    expect(instance.clients.length).to.equal(3);
+                    redisClient2.end();
+
+                    instance.reconnectAllClients();
+
+                    expect(redisClient2.info()).to.not.be.ok;
+
+                    redisClient1.info(function(err, info) {
+                        expect(err).to.be.null;
+                        expect(info).to.be.ok;
+
+                        done();
+                    });
+                });
+            });
+        });
+    });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -210,6 +210,7 @@ describe('Redis Sentinel tests', function() {
                     redisClient2.end();
 
                     instance.reconnectAllClients();
+                    expect(instance.clients.length).to.equal(2);
 
                     expect(redisClient2.info()).to.not.be.ok;
 


### PR DESCRIPTION
The internal clients array will retain closed redis connections; this change:

1. when reconnecting, filters out any clients that are in 'closing' state
2. watches for client end, and removes from clients array if appropriate