### PR TITLE
More connection management cleanup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,26 @@ var sentinelClient = sentinel.createClient(endpoints, {role: 'sentinel'});
 
 Where you should also transparently get a reconnection to a new slave/sentinel if the existing one goes down.
 
+## Connection Management ##
+
+By default node-redis-sentinel will attempt to reconnect any existing redis clients when a failover is
+detected. In some cases you'll want to manage your own connection lifetime and tell node-redis-sentinel
+not to maintain a reference to the redis client -- you can pass explicitly set the 'sentinel_managed'
+option to false when creating a client:
+
+```javascript
+var sentinel = require('redis-sentinel');
+
+var endpoints = [
+    {host: '127.0.0.1', port: 26379},
+    {host: '127.0.0.1', port: 26380}
+];
+var masterName = 'mymaster';
+
+var Sentinel = sentinel.Sentinel(endpoints);
+var masterClient = Sentinel.createClient(masterName, {sentinel_managed: false});
+```
+
 ## TODO ##
 * We could probably be cleverer with reconnects etc. and there may be issues with the error handling
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Where you should also transparently get a reconnection to a new slave/sentinel i
 
 By default node-redis-sentinel will attempt to reconnect any existing redis clients when a failover is
 detected. In some cases you'll want to manage your own connection lifetime and tell node-redis-sentinel
-not to maintain a reference to the redis client -- you can pass explicitly set the 'sentinel_managed'
+not to maintain a reference to the redis client -- you can explicitly set the 'sentinel_managed'
 option to false when creating a client:
 
 ```javascript


### PR DESCRIPTION
Two things, which maybe ought to be split apart:
1. node-redis explicitly clears the event observers on the underlying stream when calling client.end(); this means we'll never get an end event, and we'll never clean our clients array unless we get a sentinel failover.  Work around this by explicitly filtering closing clients when creating a new client.
2. I'm vaguely concerned about life cycle for clients that hit a handled error, for whatever reason -- it's not clear to me that we get any closing event (or even that we can reconnect).  Create a concept of unmanaged connections, and slide it into the createClient options.

I'm happy to break this into different commits / remove the second, honestly.  Thank you!
