### PR TITLE
removing listeners while refreshing end points to prevent dupe events

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,6 +109,7 @@ Sentinel.prototype.createClientInternal = function(masterName, opts) {
             function refreshEndpoints() {
                 client.connectionOption.port = "";
                 client.connectionOption.host = "";
+                client.stream.removeAllListeners();
                 resolver(self.endpoints, masterName, function(_err, ip, port) {
                     if (_err) {
                         oldEmit.call(client, 'error', _err);


### PR DESCRIPTION
This is the patch suggested by @StevenRoan in https://github.com/ortoo/node-redis-sentinel/issues/31
It works for me so I just wanted to actually submitted it as a PR so others may benefit.

