### PR TITLE
End the old stream before reconnecting

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,7 +113,9 @@ Sentinel.prototype.createClientInternal = function(masterName, opts) {
                     if (_err) {
                         oldEmit.call(client, 'error', _err);
                     } else {
-                        // Try reconnecting.
+                        // Try reconnecting - remove the old stream first.
+                        client.stream.end();
+                        
                         client.connectionOption.port = port;
                         client.connectionOption.host = ip;
                         client.connection_gone("sentinel induced refresh");


### PR DESCRIPTION
If a manual failover has occurred then the old stream will be still hanging around. We should end it