### PR TITLE
Add address to client

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,6 +86,7 @@ Sentinel.prototype.createClientInternal = function(masterName, opts) {
                 port: port,
                 host: host
             };
+            client.address = host + ':' + port;
             client.connectionOption = connectionOption;
             client.stream.connect(connectionOption.port, connectionOption.host);
 


### PR DESCRIPTION
When the connection fails, the error message is
`Error: Redis connection to undefined failed - connect ETIMEDOUT`

This line in redis is responsible for setting client.address:
https://github.com/mranney/node_redis/blob/master/index.js#L1273

The change fixes the error message so it shows
`Error: Redis connection to 127.0.0.1:6379 failed - connect ETIMEDOUT`
