### PR TITLE
Fix ReferenceError

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,18 +31,17 @@ Sentinel.prototype.createClient = function(masterName, opts) {
         var pubsubOpts = {};
         pubsubOpts.role = "sentinel";
         pubsubClient = this.createClientInternal(masterName, pubsubOpts);
-        pubsubClient.subscribe("+switch-master", function(error) {
-            if (error) {
-                console.error("Unable to subscribe to Sentinel PUBSUB",
-                              host, ":", port);
-            }
-        });
+        pubsubClient.subscribe("+switch-master");
         pubsubClient.on("message", function(channel, message) {
             console.warn("Received +switch-master message from Redis Sentinel.",
                          " Reconnecting clients.");
             self.reconnectAllClients();
         });
-        pubsubClient.on("error", function(error) {});
+        pubsubClient.on("error", function(error) {
+            if (error) {
+                console.error("PubSub client has an error: " + error);
+            }
+        });
         self.pubsub.push(pubsubClient);
     }
     return this.createClientInternal(masterName, opts);


### PR DESCRIPTION
After shutting down the Redis master, the following error was reported in the console:

ReferenceError: host is not defined
     ERR     at Command.callback (node_modules/redis-sentinel/index.js:37:31)

Thus I have removed the callback from the pubsubClient.subscribe("+switch-master") function and added a console output to pubsubClient.on("error") instead.

Tested with Node.js 0.10.33 and Redis 2.8.19.
