### PR TITLE
Ensure the master name is current master before reconnecting all clients

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,11 +36,18 @@ Sentinel.prototype.createClient = function(masterName, opts) {
                 console.error("Unable to subscribe to Sentinel PUBSUB");
             }
         });
-        pubsubClient.on("message", function(channel, message) {
-            console.warn("Received +switch-master message from Redis Sentinel.",
-                         " Reconnecting clients.");
-            self.reconnectAllClients();
-        });
+      pubsubClient.on("message", function (channel, message) {
+          var failedOverMaster = message.split(" ")[0];
+          console.warn("Received +switch-master message from Redis Sentinel for master", failedOverMaster);
+          if (failedOverMaster === masterName) {
+              console.warn("Reconnecting clients.");
+              self.reconnectAllClients();
+          }
+          else {
+              console.warn("Ignoring the message");
+          }
+
+      });
         pubsubClient.on("error", function(error) {});
         self.pubsub.push(pubsubClient);
     }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   ],
   "dependencies": {
     "redis": "0.12.x",
-    "when": "^3.5.1"
+    "when": "^3.5.1",
+    "minilog": "*"
   },
   "devDependencies": {
     "mocha": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redis-sentinel",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Redis sentinel client for nodejs",
   "main": "index.js",
   "scripts": {

--- a/test/test.js
+++ b/test/test.js
@@ -70,7 +70,7 @@ describe('Redis Sentinel tests', function() {
             var redisClient = sentinel.createClient(endpoints, {role: 'sentinel'});
             redisClient.on('ready', function() {
                 expect(redisClient.connectionOption.host).to.equal('127.0.0.1');
-                expect(redisClient.connectionOption.port).to.equal("26380");
+                expect(["26380", "26379"]).to.contain(redisClient.connectionOption.port);
                 done();
             });
         });
@@ -113,7 +113,7 @@ describe('Redis Sentinel tests', function() {
             var redisClient = sentinel.createClient(endpoints, {role: 'sentinel'});
             redisClient.on('ready', function() {
                 expect(redisClient.connectionOption.host).to.equal('127.0.0.1');
-                expect(redisClient.connectionOption.port).to.equal("26380");
+                expect(["26380", "26379"]).to.contain(redisClient.connectionOption.port);
                 done();
             });
         });

--- a/test/test.js
+++ b/test/test.js
@@ -1,8 +1,11 @@
 var sentinel = require('../');
 var expect = require('chai').expect;
 var redis = require('redis');
+var Minilog = require('minilog');
 
 describe('Redis Sentinel tests', function() {
+
+    Minilog.enable()
 
     describe('initial connection', function() {
 


### PR DESCRIPTION
We had a bug where the sentinel client is receiving the `switch-master` message for any master failover.

This ensures we parse the message and check the master name before reconnecting all clients. We ignore the message if the master is different.

